### PR TITLE
Add command to view a report

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/giantswarm/lighthouse-keeper/cmd/compare"
+	"github.com/giantswarm/lighthouse-keeper/cmd/view"
 )
 
 var RootCmd = &cobra.Command{
@@ -16,6 +17,7 @@ var RootCmd = &cobra.Command{
 
 func init() {
 	RootCmd.AddCommand(compare.Cmd)
+	RootCmd.AddCommand(view.Cmd)
 }
 
 // Execute is called by main to run the CLI

--- a/cmd/view/cmd.go
+++ b/cmd/view/cmd.go
@@ -1,0 +1,121 @@
+// Package view provides the `view` command to print a lighthouse report
+package view
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/giantswarm/microerror"
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/lighthouse-keeper/service/parser"
+)
+
+// Cmd is our cobra command
+var Cmd = &cobra.Command{
+	Use:     "view",
+	Short:   "Print a Lighthouse report",
+	PreRunE: validateFlags,
+	Run:     view,
+}
+
+func init() {
+	Cmd.Flags().StringP("input", "i", "", "Input file path")
+	Cmd.Flags().BoolP("omit-done", "o", false, "Avoid praising yourself, hide audit rows showing full score")
+}
+
+func view(cmd *cobra.Command, args []string) {
+	input, err := cmd.Flags().GetString("input")
+	if err != nil {
+		fmt.Println("Error while reading --input flag:")
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	omitDone, err := cmd.Flags().GetBool("omit-done")
+	if err != nil {
+		fmt.Println("Error while reading --omit-done flag:")
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	var report *parser.Report
+	{
+		data, err := ioutil.ReadFile(input)
+		if err != nil {
+			fmt.Printf("Error while reading file %q:\n", input)
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+		report, err = parser.ParseReportJSON(data)
+		if err != nil {
+			fmt.Printf("Error while parsing report %q:\n", input)
+			fmt.Println(err)
+			os.Exit(1)
+		}
+	}
+
+	// output table data
+	data := [][]string{}
+
+	// Print by category, then by audit
+	for _, cat := range report.Categories {
+		row := []string{
+			cat.Title,
+			fmt.Sprintf("%.0f", cat.Score*100),
+		}
+
+		data = append(data, row)
+
+		// individual audits
+		for _, auditRef := range cat.AuditRefs {
+			audit, ok := report.Audits[auditRef.ID]
+			if !ok {
+				continue
+			}
+
+			score := fmt.Sprintf("%.0f", audit.Score*100)
+
+			if omitDone && score == "100" {
+				continue
+			}
+
+			row := []string{
+				"- " + audit.Title,
+				score,
+			}
+
+			data = append(data, row)
+		}
+	}
+
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetAutoWrapText(false)
+	labels := []string{"Metric", "Score"}
+	table.SetHeader(labels)
+
+	for _, v := range data {
+		table.Append(v)
+	}
+
+	table.Render()
+}
+
+func validateFlags(cmd *cobra.Command, args []string) error {
+	if cmd.Flag("input") == nil {
+		return microerror.Maskf(invalidFlagsError, "please specify a reports to compare using the --input/-i flag")
+	}
+
+	input, err := cmd.Flags().GetString("input")
+	if err != nil {
+		return microerror.Maskf(invalidFlagsError, "could not read value for --input/-i flag")
+	}
+	if input == "" {
+		return microerror.Maskf(invalidFlagsError, "please specify a reports to compare using the --input/-i flag")
+	}
+
+	return nil
+}

--- a/cmd/view/cmd.go
+++ b/cmd/view/cmd.go
@@ -66,6 +66,7 @@ func view(cmd *cobra.Command, args []string) {
 		row := []string{
 			cat.Title,
 			fmt.Sprintf("%.0f", cat.Score*100),
+			"",
 		}
 
 		data = append(data, row)
@@ -86,6 +87,7 @@ func view(cmd *cobra.Command, args []string) {
 			row := []string{
 				"- " + audit.Title,
 				score,
+				fmt.Sprintf("%d", auditRef.Weight),
 			}
 
 			data = append(data, row)
@@ -94,7 +96,7 @@ func view(cmd *cobra.Command, args []string) {
 
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetAutoWrapText(false)
-	labels := []string{"Metric", "Score"}
+	labels := []string{"Metric", "Score", "Weight"}
 	table.SetHeader(labels)
 
 	for _, v := range data {

--- a/cmd/view/cmd.go
+++ b/cmd/view/cmd.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 
 	"github.com/giantswarm/microerror"
 	"github.com/olekukonko/tablewriter"
@@ -64,7 +65,7 @@ func view(cmd *cobra.Command, args []string) {
 	// Print by category, then by audit
 	for _, cat := range report.Categories {
 		row := []string{
-			cat.Title,
+			strings.ToUpper(cat.Title),
 			fmt.Sprintf("%.0f", cat.Score*100),
 			"",
 		}

--- a/cmd/view/error.go
+++ b/cmd/view/error.go
@@ -1,0 +1,13 @@
+package view
+
+import "github.com/giantswarm/microerror"
+
+// invalidFlagsError is used when an attempt to write some file fails
+var invalidFlagsError = &microerror.Error{
+	Kind: "invalidFlagsError",
+}
+
+// IsInvalidFlagsError asserts invalidFlagsError
+func IsInvalidFlagsError(err error) bool {
+	return microerror.Cause(err) == invalidFlagsError
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/4874

This adds a `view` command to print the data of a report.

### Preview

Using the `--omit-done` flag for shortness

```
+-----------------------------------------------------------------------------------------------------------------------------+-------+--------+
|                                                           METRIC                                                            | SCORE | WEIGHT |
+-----------------------------------------------------------------------------------------------------------------------------+-------+--------+
| PERFORMANCE                                                                                                                 |    82 |        |
| - First Contentful Paint                                                                                                    |    94 |      3 |
| - First Meaningful Paint                                                                                                    |    90 |      1 |
| - Speed Index                                                                                                               |    80 |      4 |
| - Time to Interactive                                                                                                       |    75 |      5 |
| - First CPU Idle                                                                                                            |    80 |      2 |
| - Estimated Input Latency                                                                                                   |    23 |      0 |
| - Eliminate render-blocking resources                                                                                       |    86 |      0 |
| - Properly size images                                                                                                      |    84 |      0 |
| - Defer offscreen images                                                                                                    |    87 |      0 |
| - Defer unused CSS                                                                                                          |    87 |      0 |
| - Preconnect to required origins                                                                                            |    71 |      0 |
| - Serve static assets with an efficient cache policy                                                                        |    59 |      0 |
| - Minimize Critical Requests Depth                                                                                          |     0 |      0 |
| - Network Requests                                                                                                          |     0 |      0 |
| - Metrics                                                                                                                   |     0 |      0 |
| - User Timing marks and measures                                                                                            |     0 |      0 |
| - Reduce JavaScript execution time                                                                                          |    88 |      0 |
| - Screenshot Thumbnails                                                                                                     |     0 |      0 |
| - Final Screenshot                                                                                                          |     0 |      0 |
| - Minimize main-thread work                                                                                                 |    46 |      0 |
| - Ensure text remains visible during webfont load                                                                           |     0 |      0 |
| PROGRESSIVE WEB APP                                                                                                         |    56 |        |
| - Does not respond with a 200 when offline                                                                                  |     0 |      5 |
| - User will not be prompted to Install the Web App                                                                          |     0 |      3 |
| - Does not register a service worker                                                                                        |     0 |      1 |
| - Is not configured for a custom splash screen                                                                              |     0 |      1 |
| - Address bar does not match brand colors                                                                                   |     0 |      1 |
| - Content is sized correctly for the viewport                                                                               |     0 |      0 |
| - The `short_name` won't be truncated on the homescreen                                                                     |     0 |      0 |
| - Site works cross-browser                                                                                                  |     0 |      0 |
| - Page transitions don't feel like they block on the network                                                                |     0 |      0 |
| - Each page has a URL                                                                                                       |     0 |      0 |
| ACCESSIBILITY                                                                                                               |    69 |        |
| - `[accesskey]` values are unique                                                                                           |     0 |      0 |
| - `[aria-*]` attributes match their roles                                                                                   |     0 |      0 |
| - `[role]`s have all required `[aria-*]` attributes                                                                         |     0 |      0 |
| - Elements with `[role]` that require specific children `[role]`s, are present                                              |     0 |      0 |
| - `[role]`s are contained by their required parent element                                                                  |     0 |      0 |
| - `[role]` values are valid                                                                                                 |     0 |      0 |
| - `[aria-*]` attributes have valid values                                                                                   |     0 |      0 |
| - `[aria-*]` attributes are valid and not misspelled                                                                        |     0 |      0 |
| - `<audio>` elements contain a `<track>` element with `[kind="captions"]`                                                   |     0 |      0 |
| - Background and foreground colors do not have a sufficient contrast ratio.                                                 |     0 |      6 |
| - `<dl>`'s contain only properly-ordered `<dt>` and `<dd>` groups, `<script>` or `<template>` elements.                     |     0 |      0 |
| - Definition list items are wrapped in `<dl>` elements                                                                      |     0 |      0 |
| - `[id]` attributes on the page are not unique                                                                              |     0 |      5 |
| - `<frame>` or `<iframe>` elements have a title                                                                             |     0 |      0 |
| - `<input type="image">` elements have `[alt]` text                                                                         |     0 |      0 |
| - Form elements do not have associated labels                                                                               |     0 |     10 |
| - Presentational `<table>` elements avoid using `<th>`, `<caption>` or the `[summary]` attribute.                           |     0 |      0 |
| - The document does not use `<meta http-equiv="refresh">`                                                                   |     0 |      0 |
| - `[user-scalable="no"]` is used in the `<meta name="viewport">` element or the `[maximum-scale]` attribute is less than 5. |     0 |      3 |
| - `<object>` elements have `[alt]` text                                                                                     |     0 |      0 |
| - No element has a `[tabindex]` value greater than 0                                                                        |     0 |      0 |
| - Cells in a `<table>` element that use the `[headers]` attribute only refer to other cells of that same table.             |     0 |      0 |
| - `<th>` elements and elements with `[role="columnheader"/"rowheader"]` have data cells they describe.                      |     0 |      0 |
| - `[lang]` attributes have a valid value                                                                                    |     0 |      0 |
| - `<video>` elements contain a `<track>` element with `[kind="captions"]`                                                   |     0 |      0 |
| - `<video>` elements contain a `<track>` element with `[kind="description"]`                                                |     0 |      0 |
| - The page has a logical tab order                                                                                          |     0 |      0 |
| - Interactive controls are keyboard focusable                                                                               |     0 |      0 |
| - Interactive elements indicate their purpose and state                                                                     |     0 |      0 |
| - The user's focus is directed to new content added to the page                                                             |     0 |      0 |
| - User focus is not accidentally trapped in a region                                                                        |     0 |      0 |
| - Custom controls have associated labels                                                                                    |     0 |      0 |
| - Custom controls have ARIA roles                                                                                           |     0 |      0 |
| - Visual order on the page follows DOM order                                                                                |     0 |      0 |
| - Offscreen content is hidden from assistive technology                                                                     |     0 |      0 |
| - Headings don't skip levels                                                                                                |     0 |      0 |
| - HTML5 landmark elements are used to improve navigation                                                                    |     0 |      0 |
| BEST PRACTICES                                                                                                              |    93 |        |
| - Links to cross-origin destinations are unsafe                                                                             |     0 |      1 |
| SEO                                                                                                                         |    90 |        |
| - Links do not have descriptive text                                                                                        |     0 |      1 |
| - robots.txt is valid                                                                                                       |     0 |      0 |
| - Page is mobile friendly                                                                                                   |     0 |      0 |
| - Structured data is valid                                                                                                  |     0 |      0 |
+-----------------------------------------------------------------------------------------------------------------------------+-------+--------+
```