### PR TITLE
Add command to create a lighthouse report

### DIFF
--- a/cmd/audit/cmd.go
+++ b/cmd/audit/cmd.go
@@ -1,0 +1,91 @@
+// Package audit provides the `audit` command to create a lighthouse report.
+package audit
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/giantswarm/microerror"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/lighthouse-keeper/service/lighthouse"
+)
+
+// Cmd is our cobra command
+var Cmd = &cobra.Command{
+	Use:     "audit",
+	Short:   "Create a Lighthouse report",
+	PreRunE: validateFlags,
+	Run:     audit,
+	Example: `
+  lighthouse-keeper audit --url https://example.com/
+
+  lighthouse-keeper audit --form-factor mobile --url https://example.com/
+
+  lighthouse-keeper audit --name mysite --form-factor mobile --url https://example.com/
+
+  lighthouse-keeper audit \
+    --name first-name --url http://first-url \
+    --name second-name --url http://second-url`,
+}
+
+func init() {
+	Cmd.Flags().StringArrayP("url", "u", []string{}, "URL to audit, can be used multiple times")
+	Cmd.Flags().StringArrayP("name", "n", []string{}, "Output file name prefix, can be used multiple times")
+	Cmd.Flags().StringP("form-factor", "f", "desktop", "Either 'desktop' or 'mobile")
+}
+
+func audit(cmd *cobra.Command, args []string) {
+	urls, err := cmd.Flags().GetStringArray("url")
+	if err != nil {
+		fmt.Println("Error while reading --url flag:")
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	names, err := cmd.Flags().GetStringArray("name")
+	if err != nil {
+		fmt.Println("Error while reading --name flag:")
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	formFactor, err := cmd.Flags().GetString("form-factor")
+	if err != nil {
+		fmt.Println("Error while reading --name flag:")
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	for index, url := range urls {
+		// set automatic output name if none given
+		if len(names) < (index + 1) {
+			t := time.Now()
+			names = append(names, t.Format("20060102-150405")+fmt.Sprintf("-%s-%d", formFactor, index+1))
+		}
+
+		_, err := lighthouse.AuditURL(url, names[index], formFactor)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+	}
+
+}
+
+func validateFlags(cmd *cobra.Command, args []string) error {
+	if cmd.Flag("url") == nil {
+		return microerror.Maskf(invalidFlagsError, "please specify at least one URL to audit using the --url/-u flag")
+	}
+
+	inputs, err := cmd.Flags().GetStringArray("url")
+	if err != nil {
+		return microerror.Maskf(invalidFlagsError, "could not read values for --url/-u flag")
+	}
+	if len(inputs) < 1 {
+		return microerror.Maskf(invalidFlagsError, "please specify at least one URL to audit via the --url/-u flag")
+	}
+
+	return nil
+}

--- a/cmd/audit/error.go
+++ b/cmd/audit/error.go
@@ -1,0 +1,13 @@
+package audit
+
+import "github.com/giantswarm/microerror"
+
+// invalidFlagsError is used when an attempt to write some file fails
+var invalidFlagsError = &microerror.Error{
+	Kind: "invalidFlagsError",
+}
+
+// IsInvalidFlagsError asserts invalidFlagsError
+func IsInvalidFlagsError(err error) bool {
+	return microerror.Cause(err) == invalidFlagsError
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/giantswarm/lighthouse-keeper/cmd/audit"
 	"github.com/giantswarm/lighthouse-keeper/cmd/compare"
 	"github.com/giantswarm/lighthouse-keeper/cmd/view"
 )
@@ -16,6 +17,7 @@ var RootCmd = &cobra.Command{
 }
 
 func init() {
+	RootCmd.AddCommand(audit.Cmd)
 	RootCmd.AddCommand(compare.Cmd)
 	RootCmd.AddCommand(view.Cmd)
 }

--- a/service/lighthouse/lighthouse.go
+++ b/service/lighthouse/lighthouse.go
@@ -1,0 +1,63 @@
+// Package lighthouse provides the lighthouse auditing service.
+package lighthouse
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+
+	"github.com/giantswarm/microerror"
+)
+
+// AuditURL creates a lighthouse report and returns the path
+func AuditURL(url, name, formFactor string) (path string, err error) {
+	fmt.Printf("Creating lighthouse report\nURL: %s\nForm factor: %s\nOutput file: %s.json\n", url, formFactor, name)
+
+	pwd, err := os.Getwd()
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	tmpDir, err := ioutil.TempDir("/tmp", "lighthouse-temp")
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	if formFactor != "desktop" && formFactor != "mobile" {
+		formFactor = "desktop"
+	}
+
+	args := []string{
+		"run",
+		"--rm",
+		"--tty",
+		fmt.Sprintf("-v=%s:/workdir", pwd),
+		fmt.Sprintf("-v=%s:/dev/shm", tmpDir),
+		"-w=/workdir",
+		"quay.io/giantswarm/lighthouse:latest",
+		"lighthouse",
+		"--quiet",
+		"--no-enable-error-reporting",
+		"--output=json",
+		"--chrome-flags=--no-sandbox --headless",
+		fmt.Sprintf("--emulated-form-factor=%s", formFactor),
+		fmt.Sprintf("--output-path=/workdir/%s.json", name),
+		url,
+	}
+
+	command := exec.Command("docker", args...)
+	var stdout, stderr bytes.Buffer
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+	err = command.Run()
+	if err != nil {
+		_, errStr := string(stdout.Bytes()), string(stderr.Bytes())
+		fmt.Printf("%s\n", errStr)
+		return "", microerror.Mask(fmt.Errorf("cmd.Run() failed with %s", err))
+	}
+
+	return fmt.Sprintf("%s.json", name), nil
+}


### PR DESCRIPTION
### Preview

```
lighthouse-keeper audit --help
Create a Lighthouse report

Usage:
  lighthouse-keeper audit [flags]

Examples:

  lighthouse-keeper audit --url https://example.com/

  lighthouse-keeper audit --form-factor mobile --url https://example.com/

  lighthouse-keeper audit --name mysite --form-factor mobile --url https://example.com/

  lighthouse-keeper audit \
    --name first-name --url http://first-url \
    --name second-name --url http://second-url

Flags:
  -f, --form-factor string   Either 'desktop' or 'mobile (default "desktop")
  -h, --help                 help for audit
  -n, --name stringArray     Output file name prefix, can be used multiple times
  -u, --url stringArray      URL to audit, can be used multiple times
```