### PR TITLE
Add flag to 'audit' command to ignore certificate errors

### DIFF
--- a/cmd/audit/cmd.go
+++ b/cmd/audit/cmd.go
@@ -37,6 +37,7 @@ func init() {
 	Cmd.Flags().StringArrayP("name", "n", []string{}, "Output file name prefix, can be used multiple times")
 	Cmd.Flags().StringP("form-factor", "f", "desktop", "Either 'desktop' or 'mobile")
 	Cmd.Flags().StringArrayP("docker-link", "l", []string{}, "Link the lighthouse docker container to these named links")
+	Cmd.Flags().BoolP("ignore-certificate-errors", "", false, "Ignore certificate errors")
 }
 
 func audit(cmd *cobra.Command, args []string) {
@@ -68,6 +69,13 @@ func audit(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
+	ignoreCertErrors, err := cmd.Flags().GetBool("ignore-certificate-errors")
+	if err != nil {
+		fmt.Println("Error while reading --ignore-certificate-errors flag:")
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
 	for index, url := range urls {
 		// set automatic output name if none given
 		if len(names) < (index + 1) {
@@ -75,7 +83,7 @@ func audit(cmd *cobra.Command, args []string) {
 			names = append(names, t.Format("20060102-150405")+fmt.Sprintf("-%s-%d", formFactor, index+1))
 		}
 
-		_, err := lighthouse.AuditURL(url, names[index], formFactor, dockerLinks)
+		_, err := lighthouse.AuditURL(url, names[index], formFactor, dockerLinks, ignoreCertErrors)
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)

--- a/service/lighthouse/lighthouse.go
+++ b/service/lighthouse/lighthouse.go
@@ -12,7 +12,7 @@ import (
 )
 
 // AuditURL creates a lighthouse report and returns the path
-func AuditURL(url, name, formFactor string, dockerLinks []string) (path string, err error) {
+func AuditURL(url, name, formFactor string, dockerLinks []string, ignoreCertErrors bool) (path string, err error) {
 	fmt.Printf("Creating lighthouse report\nURL: %s\nForm factor: %s\nOutput file: %s.json\n", url, formFactor, name)
 
 	pwd, err := os.Getwd()
@@ -28,6 +28,11 @@ func AuditURL(url, name, formFactor string, dockerLinks []string) (path string, 
 
 	if formFactor != "desktop" && formFactor != "mobile" {
 		formFactor = "desktop"
+	}
+
+	ignoreCertErrorsFlag := ""
+	if ignoreCertErrors {
+		ignoreCertErrorsFlag = "--ignore-certificate-errors"
 	}
 
 	linkArgs := []string{}
@@ -50,7 +55,7 @@ func AuditURL(url, name, formFactor string, dockerLinks []string) (path string, 
 		"--quiet",
 		"--no-enable-error-reporting",
 		"--output=json",
-		"--chrome-flags=--no-sandbox --headless",
+		fmt.Sprintf("--chrome-flags=--no-sandbox --headless %s", ignoreCertErrorsFlag),
 		fmt.Sprintf("--emulated-form-factor=%s", formFactor),
 		fmt.Sprintf("--output-path=/workdir/%s.json", name),
 		url,


### PR DESCRIPTION
This adds the `--ignore-certificate-errors` flag to the `audit` command, which is simply pased through as a chrome flag. It should allow auditing against self-signed certificates.