### PR TITLE
Don't send comment when no differences

### DIFF
--- a/DCO
+++ b/DCO
@@ -1,0 +1,36 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+660 York Street, Suite 102,
+San Francisco, CA 94110 USA
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.

--- a/cmd/compare/cmd.go
+++ b/cmd/compare/cmd.go
@@ -243,13 +243,13 @@ func compare(cmd *cobra.Command, args []string) {
 
 				body = "Comparison of lighthouse reports:\n\n"
 				body += buf.String()
-			} else {
-				body = fmt.Sprintf("Comparison of lighthouse reports between `%s` and `%s` showed no difference.", inputLabel[0], inputLabel[1])
 			}
 
-			err = commenter.AddComment(token, owner, repo, body, issue)
-			if err != nil {
-				fmt.Println(err)
+			if body != "" {
+				err = commenter.AddComment(token, owner, repo, body, issue)
+				if err != nil {
+					fmt.Println(err)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This PR disables comment if no differences have been found in lighthouse report comparison.